### PR TITLE
Upgrade project to .NET 9

### DIFF
--- a/IntraPortal/IntraPortal.csproj
+++ b/IntraPortal/IntraPortal.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>IntraPortal</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.6.24328.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.6.24328.4" />
   </ItemGroup>
 </Project>
 


### PR DESCRIPTION
## Summary
- retarget the web project to .NET 9
- align Entity Framework Core dependencies with the .NET 9 toolchain

## Testing
- `dotnet build` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d001feaefc832cb899d361ea3e961e